### PR TITLE
[POL-61] sharepoint integration

### DIFF
--- a/lib/voyager/clients/microsoft_graph_client.rb
+++ b/lib/voyager/clients/microsoft_graph_client.rb
@@ -15,8 +15,10 @@ module Voyager
       super(options)
     end
 
-    def authorize_url(redirect_uri, options = {})
-      super(redirect_uri, options.merge(scope: options[:scope].join(' ')))
+    def authorize_url(redirect_uri, addl_configs = {})
+      scope = addl_configs.delete(:scope) || options[:scope]
+      auth_options = options.merge(scope: scope.join(' ')).merge(addl_configs)
+      super(redirect_uri, auth_options)
     end
 
     def connected?
@@ -51,6 +53,34 @@ module Voyager
 
     def drive_items(item_id = 'root', options = {})
       get("/me/drive/#{item_id}/children", options)
+    end
+
+    def drive_children(drive_ids)
+      drive_ids.map do |drive_id|
+        get("/drives/#{drive_id}/root/children")
+      end
+    end
+
+    # ============================================================================
+    # Sites
+    # ============================================================================
+
+    def site_root
+      get('/sites/root')
+    end
+
+    def sub_sites(site_id)
+      get("/sites/#{site_id}/sites")
+    end
+
+    def followed_sites
+      get('/me/followedSites')
+    end
+
+    def site_drives(site_ids)
+      site_ids.map do |site_id|
+        get("/sites/#{site_id}/drives")
+      end
     end
 
     protected

--- a/lib/voyager/version.rb
+++ b/lib/voyager/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Voyager
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end


### PR DESCRIPTION
ticket: https://careerarc.atlassian.net/browse/POL-61

Updates `MicrosoftGraftClient`: 
-- refactor `initialize` to avoid naming collision with inherited attr `options`
-- add sharepoint-specific endpoints: `site_root`, `sub_sites`, `followed_sites` and `site_drives`
-- adds `drives/#{drive_id}/root/children` for use with drive_ids obtained from `#site_drives`
-- adds specs