### PR TITLE
[Pol-657] revert client build request change

### DIFF
--- a/lib/voyager/client.rb
+++ b/lib/voyager/client.rb
@@ -94,7 +94,7 @@ module Voyager
     def build_request(request)
       http_request = case request.method
         when :get
-          Net::HTTP::Get.new(request.uri.path)
+          Net::HTTP::Get.new(request.uri.to_s)
         when :post
           multipart?(request.body) ?
             Net::HTTP::Post::Multipart.new(request.uri.path, to_multipart_params(request.body)) :

--- a/lib/voyager/clients/microsoft_graph_client.rb
+++ b/lib/voyager/clients/microsoft_graph_client.rb
@@ -85,6 +85,27 @@ module Voyager
 
     protected
 
+    ### TEMPORARY; OTHER CLIENTS NEED ORIGINAL FORM ###
+    def build_request(request)
+      http_request = case request.method
+        when :get
+          Net::HTTP::Get.new(request.uri.path)
+        when :post
+          multipart?(request.body) ?
+            Net::HTTP::Post::Multipart.new(request.uri.path, to_multipart_params(request.body)) :
+            Net::HTTP::Post.new(request.uri.path).tap do |req|
+              req["Content-Type"] ||= "application/x-www-form-urlencoded"
+              req.body = transform_body(request.body)
+            end
+        else
+          raise ArgumentError, "Unsupported method '#{request.method}'"
+        end
+
+      request.headers.each { |key,value| http_request[key] = value }
+      http_request
+    end
+    ###################################################
+
     def get(path, params = {})
       super(path + build_query(params))
     end

--- a/lib/voyager/version.rb
+++ b/lib/voyager/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Voyager
-  VERSION = '0.1.9'
+  VERSION = '0.1.10'
 end


### PR DESCRIPTION
Ticket: https://careerarc.atlassian.net/browse/POL-657

Reverts prior change to `Client#build_request`; was dropping params on calls to Twitter api. 
Moves `#build_request` with Sharepoint-specific changes into `MicrosoftGraphClient`, temporarily. 