### PR TITLE
Pol 887/add sharepoint search endpoints

### DIFF
--- a/lib/voyager/client.rb
+++ b/lib/voyager/client.rb
@@ -56,7 +56,7 @@ module Voyager
 
     def post(path, body='', headers={})
       update_runtime_terms(body) if body.is_a?(Hash)
-      perform_request(:post, path, body)
+      perform_request(:post, path, body, headers)
     end
 
     # ============================================================================
@@ -99,7 +99,7 @@ module Voyager
           multipart?(request.body) ?
             Net::HTTP::Post::Multipart.new(request.uri.path, to_multipart_params(request.body)) :
             Net::HTTP::Post.new(request.uri.path).tap do |req|
-              req["Content-Type"] ||= "application/x-www-form-urlencoded"
+              req['Content-Type'] ||= (request.headers['Content-Type'] || 'application/x-www-form-urlencoded')
               req.body = transform_body(request.body)
             end
         else

--- a/lib/voyager/clients/microsoft_graph_client.rb
+++ b/lib/voyager/clients/microsoft_graph_client.rb
@@ -39,51 +39,52 @@ module Voyager
       get('/me', select: fields)
     end
 
+    def search(options = {})
+      post('/search/query', options[:body], options[:headers] || {})
+    end
+
     # ============================================================================
     # Files
     # ============================================================================
 
-    def drives
+    def my_drives
       get('/me/drives')
     end
 
-    def drive
+    def my_drive
       get('/me/drive')
     end
 
-    def drive_items(item_id = 'root', options = {})
+    def my_drive_items(item_id = 'root', options)
       get("/me/drive/#{item_id}/children", options)
     end
 
-    def drive_children(drive_ids)
-      drive_ids.map do |drive_id|
-        get("/drives/#{drive_id}/root/children")
-      end
+    def drive(drive_id, query_opts = '')
+      get("/drives/#{drive_id}" + "#{query_opts.presence}")
     end
 
-    # ============================================================================
-    # Sites
-    # ============================================================================
-
-    def site_root
-      get('/sites/root')
+    def drive_item(drive_id, item_id, query_opts = '')
+      get("/drives/#{drive_id}/items/#{item_id}" + "#{query_opts.presence}")
     end
 
-    def sub_sites(site_id)
-      get("/sites/#{site_id}/sites")
+    def list(site_id, list_id, query_opts = '')
+      get("/sites/#{site_id}/lists/#{list_id}" + query_opts)
     end
 
-    def followed_sites
-      get('/me/followedSites')
-    end
-
-    def site_drives(site_ids)
-      site_ids.map do |site_id|
-        get("/sites/#{site_id}/drives")
-      end
+    def list_item(site_id, list_id, item_id, query_opts = '')
+      get("/sites/#{site_id}/lists/#{list_id}/items/#{item_id}" + query_opts)
     end
 
     protected
+
+    def add_standard_headers(headers = {})
+      additional_headers = {
+        'Accept' => 'application/json',
+        'Content-Type' => 'application/json',
+      }
+
+      super(additional_headers.merge(headers))
+    end
 
     def get(path, params = {})
       super(path + build_query(params))

--- a/lib/voyager/clients/microsoft_graph_client.rb
+++ b/lib/voyager/clients/microsoft_graph_client.rb
@@ -55,16 +55,16 @@ module Voyager
       get('/me/drive')
     end
 
-    def my_drive_items(item_id = 'root', options)
-      get("/me/drive/#{item_id}/children", options)
+    def my_drive_items(item_id = 'root', options = '')
+      get("/me/drive/#{item_id}/children" + options)
     end
 
     def drive(drive_id, query_opts = '')
-      get("/drives/#{drive_id}" + "#{query_opts.presence}")
+      get("/drives/#{drive_id}" + query_opts)
     end
 
     def drive_item(drive_id, item_id, query_opts = '')
-      get("/drives/#{drive_id}/items/#{item_id}" + "#{query_opts.presence}")
+      get("/drives/#{drive_id}/items/#{item_id}" + query_opts)
     end
 
     def list(site_id, list_id, query_opts = '')

--- a/spec/microsoft_graph_spec.rb
+++ b/spec/microsoft_graph_spec.rb
@@ -20,6 +20,10 @@ describe MicrosoftGraphClient do
     expect(query['redirect_uri']).to eq('https://example.com/callback')
   end
 
+  before do
+    config.client.refresh!
+  end
+
   context 'with valid credentials' do
     it 'is authorized' do
       expect(config.client).to be_authorized
@@ -31,6 +35,21 @@ describe MicrosoftGraphClient do
 
         expect(response).to be_successful
         expect(response.data['userPrincipalName']).not_to be_nil
+      end
+    end
+
+    describe '#search' do
+      it 'queries the search API' do
+        config.client.refresh!
+        body = {:requests=>[{:entityTypes=>["drive"], :query=>{:queryString=>"careerarc"}}]}
+        response = config.client.search(body: body)
+
+        hits = response.data['value'].first['hitsContainers'].first['hits']
+        types = hits.map { |h| h.dig('resource', '@odata.type') }.uniq
+
+        expect(response).to be_successful
+        expect(hits.empty?).to be false
+        expect(types.all?{|t| t == '#microsoft.graph.drive'}).to be true
       end
     end
 


### PR DESCRIPTION
ticket: https://careerarc.atlassian.net/browse/POL-887

changes related to this Polaris ticket: https://careerarc.atlassian.net/browse/POL-803

Changes:

add MicrosoftGraphClient#search
refactor Client#post to pass headers through to perform_request
refactor Client#perform_request to check for 'Content-Type' in request.headers before setting to previous hard-coded value (application/x-www-form-urlencoded)
Add spec for #search to MicrosoftGraphClient
Add updated token and refresh_token to spec_config.yml
refresh client in before block in MicrosoftGraphClient