### PR TITLE
[POL-996] linkedin post images

### DIFF
--- a/lib/voyager/client.rb
+++ b/lib/voyager/client.rb
@@ -154,6 +154,17 @@ module Voyager
       body
     end
 
+    def with_site(new_site, &block)
+      original_site = options[:site]
+      options[:site] = new_site
+
+      begin
+        yield
+      ensure
+        options[:site] = original_site
+      end
+    end
+
     # ============================================================================
     # Response handling
     # ============================================================================

--- a/lib/voyager/clients/facebook_client.rb
+++ b/lib/voyager/clients/facebook_client.rb
@@ -174,6 +174,18 @@ module Voyager
       post("/#{page_id}/tabs", options)
     end
 
+    # ============================================================================
+    # Metrics
+    # ============================================================================
+
+    def insights(object_id = 'me', options = {})
+      get("/#{object_id}/insights", options)
+    end
+
+    def feed(options = {})
+      get('/me/feed', options)
+    end
+
     protected
 
     def extract_edge!(options = {})

--- a/lib/voyager/clients/linked_in_client.rb
+++ b/lib/voyager/clients/linked_in_client.rb
@@ -38,6 +38,33 @@ module Voyager
     end
 
     # ============================================================================
+    # Assets - for sharing multi-image posts
+    # ============================================================================
+
+    def register_upload(options={})
+      post("/assets?action=registerUpload", options)
+    end
+
+    def upload_status(asset_id)
+      get("/assets/#{asset_id}")
+    end
+
+    def upload(url, opts={})
+      # TODO: figure out how to use standard Net::HTTP request to do this.
+      # Known issue: Documentation recommends PUT request, but API responds
+      # to PUT reqeusts saying they're not allowed.
+      resp = %x{
+        curl -iv --upload-file \
+          \"#{Voyager::Util.upload_from(opts[:source]).local_path}\" \
+          \"#{URI(url)}\" \
+          -H "Authorization: Bearer #{token}" \
+          -H 'X-Restli-Protocol-Version: 2.0.0'
+      }
+
+      Voyager::Response.new(opts[:id], resp, response_parser)
+    end
+
+    # ============================================================================
     # Account Methods - These act on the API account
     # ============================================================================
 
@@ -122,6 +149,30 @@ module Voyager
       }
 
       super(additional_headers.merge(headers))
+    end
+
+    # override Client method; some PUT endpoints require inclusion of query
+    # string, Client drops this, using request.api.path instead.
+    # Opportunity for refactor to separate out request types, minimize
+    # necessary overrides.
+    def build_request(request)
+      http_request = case request.method
+        when :get
+          Net::HTTP::Get.new(request.uri.request_uri)
+        when :post
+          multipart?(request.body) ?
+            Net::HTTP::Post::Multipart.new(request.uri.path, to_multipart_params(request.body)) :
+            Net::HTTP::Post.new(request.uri).tap do |req|
+              req['Content-Type'] ||= (request.headers['Content-Type'] || 'application/x-www-form-urlencoded')
+              req.body = transform_body(request.body)
+            end
+        else
+          raise ArgumentError, "Unsupported method '#{request.method}'"
+        end
+
+      request.headers.each { |key,value| http_request[key] = value }
+      access_token.headers.each { |key, value| http_request[key] = value }
+      http_request
     end
 
     def transform_body(body)

--- a/lib/voyager/clients/twitter_client.rb
+++ b/lib/voyager/clients/twitter_client.rb
@@ -164,11 +164,6 @@ module Voyager
       post("/statuses/update.json", options.merge(status: message))
     end
 
-    # Tweets with a picture :-)
-    def tweet_with_media(message, image, options = {})
-      post("/statuses/update_with_media.json", options.merge(:status => message, :'media[]' => image))
-    end
-
     # Destroys the status specified by the required ID parameter. The authenticating user must
     # be the author of the specified status. Returns the destroyed status if successful.
     def un_tweet(tweet_id)
@@ -199,8 +194,16 @@ module Voyager
       get('/tweets', options)
     end
 
+    def upload_media(image_url)
+      upload_io = Voyager::Util.upload_from(image_url)
+      encoded = Base64.encode64(File.read(upload_io))
+
+      with_site('https://upload.twitter.com') do
+        post('/media/upload.json', media_data: encoded)
+      end
+    end
+
     alias :update :tweet
-    alias :update_with_media :tweet_with_media
     alias :status_destroy :un_tweet
     alias :user_timeline :recent_tweets
 

--- a/lib/voyager/version.rb
+++ b/lib/voyager/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Voyager
-  VERSION = '0.1.15'
+  VERSION = '0.1.18'
 end

--- a/lib/voyager/version.rb
+++ b/lib/voyager/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Voyager
-  VERSION = '0.1.14'
+  VERSION = '0.1.15'
 end

--- a/spec/twitter_client_spec.rb
+++ b/spec/twitter_client_spec.rb
@@ -49,20 +49,6 @@ describe TwitterClient do
       response.data["id"].nil?.should be false
     end
 
-    it "can tweet with media" do
-      banner = File.new(File.expand_path("../assets/profile_banner.jpg", __FILE__))
-      response = config.client.tweet_with_media("Hello world from dimension #{rand(9999) + 1}", banner)
-      response.should be_successful
-    end
-
-    it "can tweet with media from remote url" do
-      require 'open-uri'
-      url = "http://staging-careerarc-com.s3.amazonaws.com/test/twitter_card.jpg"
-      media = open(url)
-      response = config.client.tweet_with_media("Media with remote url #{rand(9999) + 1}", media)
-      response.should be_successful
-    end
-
     it "can un-tweet" do
       account_info = config.client.account_info.data
       last_tweet_id = account_info["status"]["id"]
@@ -144,6 +130,14 @@ describe TwitterClient do
       response.should be_successful
       response.data["ids"].should be_a_kind_of Array
       response.data["ids"].size.should be > 0
+    end
+
+    it "can upload media" do
+      url = "http://staging-careerarc-com.s3.amazonaws.com/test/twitter_card.jpg"
+      response = config.client.upload_media(url)
+      response.should be_successful
+      response.data['media_id'].should be_a_kind_of Numeric
+      response.data['media_id_string'].should be_a_kind_of String
     end
 
   end


### PR DESCRIPTION
Ticket: https://careerarc.atlassian.net/browse/POL-996

Adds endpoints and other methods for sharing posts on LinkedIn, including one or more images. 

Changes: 

- adds `LinkedInClient#share`
- adds `LinkedInClient#register_upload`
- adds `LinkedInClient#upload_status` 
- adds `LinkedInClient#upload`: uses cURL command to handle upload; existing HTTP uploads weren't working even with overrides to introduce `Net::HTTP::Put` and set correct headers: LinkedInAPI wouldn't accept multipart image uploads
- overrides `Voyager::Client#build_request`: 
  - `register_upload` issues a `POST` to an endpoint that includes the params `action=registerUpload`; `Client#build_request` builds request based on path alone, stripping out params.

### NOTE [This ticket](https://careerarc.atlassian.net/browse/POL-1009) has been created to research and implement a working HTTP request to replace the current cURL request fired off by `LinkedInClient#upload`.