### PR TITLE
[POL-996] post images to LinkedIn

### DIFF
--- a/lib/voyager/clients/linked_in_client.rb
+++ b/lib/voyager/clients/linked_in_client.rb
@@ -38,6 +38,33 @@ module Voyager
     end
 
     # ============================================================================
+    # Assets - for sharing multi-image posts
+    # ============================================================================
+
+    def register_upload(options={})
+      post("/assets?action=registerUpload", options)
+    end
+
+    def upload_status(asset_id)
+      get("/assets/#{asset_id}")
+    end
+
+    def upload(url, opts={})
+      # TODO: figure out how to use standard Net::HTTP request to do this.
+      # Known issue: Documentation recommends PUT request, but API responds
+      # to PUT reqeusts saying they're not allowed.
+      resp = %x{
+        curl -iv --upload-file \
+          \"#{Voyager::Util.upload_from(opts[:source]).local_path}\" \
+          \"#{URI(url)}\" \
+          -H "Authorization: Bearer #{token}" \
+          -H 'X-Restli-Protocol-Version: 2.0.0'
+      }
+
+      Voyager::Response.new(opts[:id], resp, response_parser)
+    end
+
+    # ============================================================================
     # Account Methods - These act on the API account
     # ============================================================================
 
@@ -122,6 +149,30 @@ module Voyager
       }
 
       super(additional_headers.merge(headers))
+    end
+
+    # override Client method; some PUT endpoints require inclusion of query
+    # string, Client drops this, using request.api.path instead.
+    # Opportunity for refactor to separate out request types, minimize
+    # necessary overrides.
+    def build_request(request)
+      http_request = case request.method
+        when :get
+          Net::HTTP::Get.new(request.uri.request_uri)
+        when :post
+          multipart?(request.body) ?
+            Net::HTTP::Post::Multipart.new(request.uri.path, to_multipart_params(request.body)) :
+            Net::HTTP::Post.new(request.uri).tap do |req|
+              req['Content-Type'] ||= (request.headers['Content-Type'] || 'application/x-www-form-urlencoded')
+              req.body = transform_body(request.body)
+            end
+        else
+          raise ArgumentError, "Unsupported method '#{request.method}'"
+        end
+
+      request.headers.each { |key,value| http_request[key] = value }
+      access_token.headers.each { |key, value| http_request[key] = value }
+      http_request
     end
 
     def transform_body(body)

--- a/lib/voyager/clients/linked_in_client.rb
+++ b/lib/voyager/clients/linked_in_client.rb
@@ -151,30 +151,6 @@ module Voyager
       super(additional_headers.merge(headers))
     end
 
-    # override Client method; some PUT endpoints require inclusion of query
-    # string, Client drops this, using request.api.path instead.
-    # Opportunity for refactor to separate out request types, minimize
-    # necessary overrides.
-    def build_request(request)
-      http_request = case request.method
-        when :get
-          Net::HTTP::Get.new(request.uri.request_uri)
-        when :post
-          multipart?(request.body) ?
-            Net::HTTP::Post::Multipart.new(request.uri.path, to_multipart_params(request.body)) :
-            Net::HTTP::Post.new(request.uri).tap do |req|
-              req['Content-Type'] ||= (request.headers['Content-Type'] || 'application/x-www-form-urlencoded')
-              req.body = transform_body(request.body)
-            end
-        else
-          raise ArgumentError, "Unsupported method '#{request.method}'"
-        end
-
-      request.headers.each { |key,value| http_request[key] = value }
-      access_token.headers.each { |key, value| http_request[key] = value }
-      http_request
-    end
-
     def transform_body(body)
       JSON.unparse(body)
     end


### PR DESCRIPTION
Ticket: https://careerarc.atlassian.net/browse/POL-996

Adds endpoints and other methods for sharing posts on LinkedIn, including one or more images. 

Changes: 

- adds `LinkedInClient#share`
- adds `LinkedInClient#register_upload`
- adds `LinkedInClient#upload_status` 
- adds `LinkedInClient#upload`: uses cURL command to handle upload; existing HTTP uploads weren't working even with overrides to introduce `Net::HTTP::Put` and set correct headers: LinkedInAPI wouldn't accept multipart image uploads
- overrides `Voyager::Client#build_request`: 
  - `register_upload` issues a `POST` to an endpoint that includes the params `action=registerUpload`; `Client#build_request` builds request based on path alone, stripping out params.

### NOTE [This ticket](https://careerarc.atlassian.net/browse/POL-1009) has been created to research and implement a working HTTP request to replace the current cURL request fired off by `LinkedInClient#upload`.