### PR TITLE
Make LinkedIn upload method work without curl

### DIFF
--- a/lib/voyager/client.rb
+++ b/lib/voyager/client.rb
@@ -59,6 +59,11 @@ module Voyager
       perform_request(:post, path, body, headers)
     end
 
+    def put(path, body='', headers={})
+      update_runtime_terms(body) if body.is_a?(Hash)
+      perform_request(:put, path, body, headers)
+    end
+
     # ============================================================================
     # Core HTTP methods
     # ============================================================================
@@ -67,7 +72,7 @@ module Voyager
     def perform_request(method, path, body='', headers={})
       return Voyager::Response::Pretend.new if pretend?
 
-      uri     = URI.join(site, "#{path_prefix}#{path}")
+      uri     = path.start_with?('/') ? URI.join(site, "#{path_prefix}#{path}") : URI.parse(path)
       request = Voyager::Request.new(method, uri, body, add_standard_headers(headers))
       trace   = Voyager::Trace.begin(request, filtered_terms)
 
@@ -100,14 +105,28 @@ module Voyager
           multipart?(request.body) ?
             Net::HTTP::Post::Multipart.new(request_uri, to_multipart_params(request.body)) :
             Net::HTTP::Post.new(request_uri).tap do |req|
-              req['Content-Type'] ||= (request.headers['Content-Type'] || 'application/x-www-form-urlencoded')
               req.body = transform_body(request.body)
+            end
+        when :put
+           multipart?(request.body) ?
+            Net::HTTP::Put::Multipart.new(request_uri, to_multipart_params(request.body)) :
+            Net::HTTP::Put.new(request_uri).tap do |req|
+              if request.body.respond_to?(:to_io)
+                request.headers['Content-Type'] = Voyager::MIME.mime_type_for(request.body.path)
+                request.headers['Content-Length'] = request.body.size
+
+                req.body_stream = request.body
+              else
+                req.body = transform_body(request.body)
+              end
             end
         else
           raise ArgumentError, "Unsupported method '#{request.method}'"
         end
-
+      
+      request.headers['Content-Type'] = http_request['Content-Type'] if multipart?(request.body)
       request.headers.each { |key,value| http_request[key] = value }
+
       http_request
     end
 

--- a/lib/voyager/client.rb
+++ b/lib/voyager/client.rb
@@ -111,7 +111,7 @@ module Voyager
            multipart?(request.body) ?
             Net::HTTP::Put::Multipart.new(request_uri, to_multipart_params(request.body)) :
             Net::HTTP::Put.new(request_uri).tap do |req|
-              if request.body.respond_to?(:to_io)
+              if request.body.respond_to?(:to_io) || request.body.is_a?(UploadIO)
                 request.headers['Content-Type'] = Voyager::MIME.mime_type_for(request.body.path)
                 request.headers['Content-Length'] = request.body.size
 

--- a/lib/voyager/clients/linked_in_client.rb
+++ b/lib/voyager/clients/linked_in_client.rb
@@ -49,20 +49,24 @@ module Voyager
       get("/assets/#{asset_id}")
     end
 
-    def upload(url, opts={})
-      # TODO: figure out how to use standard Net::HTTP request to do this.
-      # Known issue: Documentation recommends PUT request, but API responds
-      # to PUT reqeusts saying they're not allowed.
-      resp = %x{
-        curl -iv --upload-file \
-          \"#{Voyager::Util.upload_from(opts[:source]).local_path}\" \
-          \"#{URI(url)}\" \
-          -H "Authorization: Bearer #{token}" \
-          -H 'X-Restli-Protocol-Version: 2.0.0'
-      }
-
-      Voyager::Response.new(opts[:id], resp, response_parser)
+    def upload(url, file)
+      put(url, file)
     end
+
+    # def upload(url, opts={})
+    #   # TODO: figure out how to use standard Net::HTTP request to do this.
+    #   # Known issue: Documentation recommends PUT request, but API responds
+    #   # to PUT reqeusts saying they're not allowed.
+    #   resp = %x{
+    #     curl -iv --upload-file \
+    #       \"#{Voyager::Util.upload_from(opts[:source]).local_path}\" \
+    #       \"#{URI(url)}\" \
+    #       -H "Authorization: Bearer #{token}" \
+    #       -H 'X-Restli-Protocol-Version: 2.0.0'
+    #   }
+
+    #   Voyager::Response.new(opts[:id], resp, response_parser)
+    # end
 
     # ============================================================================
     # Account Methods - These act on the API account


### PR DESCRIPTION
Made the following updates in order to get this working:

- Added support for `PUT` in `Client`
- Updated `Client#perform_request` to preserve absolute URLs (this probably isn't needed)
- Added logic to `Client#build_request` to put the body in the `HTTPRequest#body_stream` attribute if the given body looks like an IO object.
- Compute the 'Content-Length' and 'Content-Type' headers in this case

I tested the updating using the following script:

```
client = Voyager::LinkedInClient.new(<config omitted>)
io = File.open('/Users/stephen/Documents/repos/voyager/spec/assets/fishing_cat.jpg')

upload_opts = {"registerUploadRequest"=>
  {"owner"=>"urn:li:organization:10000",
   "recipes"=>["urn:li:digitalmediaRecipe:feedshare-image"],
   "serviceRelationships"=>
    [{"identifier"=>"urn:li:userGeneratedContent",
      "relationshipType"=>"OWNER"}],
   "supportedUploadMechanism"=>["SYNCHRONOUS_UPLOAD"]}}

resp = client.register_upload(upload_opts)

upload_url = resp.dig('value', 'uploadMechanism', 'com.linkedin.digitalmedia.uploading.MediaUploadHttpRequest', 'uploadUrl')
asset_urn = resp.dig('value', 'asset')
asset_id = asset_urn.split(':').last

status_resp = client.upload_status(asset_id)
resp = client.upload(upload_url, io)
```

I haven't updated all of my tokens to run the test suite yet, but I figured I'd share this to get the ball rolling.