### PR TITLE
Fix slack post path

### DIFF
--- a/lib/voyager/clients/slack_client.rb
+++ b/lib/voyager/clients/slack_client.rb
@@ -15,7 +15,7 @@ module Voyager
     end
 
     def share(message, options={})
-      post("", merge_default_options(options.merge(text: message)))
+      post("#{@options[:site]}#{@options[:path_prefix]}", merge_default_options(options.merge(text: message)))
     end
 
     # ============================================================================

--- a/lib/voyager/parsers/slack_parser.rb
+++ b/lib/voyager/parsers/slack_parser.rb
@@ -3,7 +3,8 @@ module Voyager
 
     def self.parse_response(response, data)
       super(response, data)
-    end
 
+      response.successful = data.is_a?(Net::HTTPOK)
+    end
   end
 end

--- a/lib/voyager/version.rb
+++ b/lib/voyager/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Voyager
-  VERSION = '0.1.28'
+  VERSION = '0.1.29'
 end


### PR DESCRIPTION
Passing an empty string was causing the request uri to be set to `URI.parse("")`

* Passes `webhook_url` instead